### PR TITLE
updated bookings to be shown again on the calendar table

### DIFF
--- a/app/controllers/bookings_controller.rb
+++ b/app/controllers/bookings_controller.rb
@@ -2,9 +2,10 @@ class BookingsController < ApplicationController
   before_action :find_booking, only: [:show, :edit, :update, :destroy]
 
   def index
-    @bookings = policy_scope(Booking).paginate(page: params[:page], per_page: 5).order(start_time: :asc)
+    @bookings = policy_scope(Booking).order(start_time: :asc)
+    # @bookings = policy_scope(Booking).paginate(page: params[:page], per_page: 5).order(start_time: :asc)
     @bookingsu = policy_scope(Booking).where('start_time > ?', Time.now).paginate(page: params[:page], per_page: 5).order(start_time: :asc)
-    @bookingsp = policy_scope(Booking).where('start_time < ?', Time.now).paginate(page: params[:page], per_page: 5).order(start_time: :asc)
+    @bookingsp = policy_scope(Booking).where('start_time < ?', Time.now).paginate(page: params[:page], per_page: 5).order(start_time: :desc)
   end
 
   def show

--- a/app/views/bookings/index.html.erb
+++ b/app/views/bookings/index.html.erb
@@ -30,7 +30,7 @@
         </li>
       </ul>
       <div class="tab-content" id="pills-tabContent">
-        <div class="tab-pane fade show active" id="pills-upcoming" role="tabpanel" aria-labelledby="pills-upcoming-tab">
+        <div class="tab-pane fade show active mb-3" id="pills-upcoming" role="tabpanel" aria-labelledby="pills-upcoming-tab">
         <% @bookingsu.each do |booking| %>
           <% if booking.start_time > Time.now %>
             <%= link_to booking_path(booking), class: "list-group-item list-group-item-action" do  %>
@@ -46,7 +46,7 @@
         <% end %>
         <%= will_paginate @bookingsu %>
         </div>
-        <div class="tab-pane fade" id="pills-past" role="tabpanel" aria-labelledby="pills-past-tab">
+        <div class="tab-pane fade mb-3" id="pills-past" role="tabpanel" aria-labelledby="pills-past-tab">
         <% @bookingsp.each do |booking| %>
           <% if booking.start_time < Time.now %>
             <%= link_to booking_path(booking), class: "list-group-item list-group-item-action" do  %>


### PR DESCRIPTION
could you please investigate the behaviour of the paginate gem as i’m not familiar with it. for instance, assuming there is at least one upcoming booking, when you click on past bookings tab and then click next page, two things happen:
1- the page goes up to the top instead of remaining at the bottom. maybe this can be fixed by what we learned on the Ajax lecture regarding adding “remote: true”
2- when you scroll down the page, instead of seeing the next page of the past bookings, not only it goes back to the Upcoming tab but it actually no longer shows the upcoming booking that was being shown before. this might be due to the fact that after clicking next in the past booking, the url now has a param “?page=2" which may prevent the upcoming to show like it was before